### PR TITLE
Fix PHP 5 syntax

### DIFF
--- a/facedetect.c
+++ b/facedetect.c
@@ -30,7 +30,7 @@
  *
  * Every user visible function must have an entry in facedetect_functions[].
  */
-static function_entry facedetect_functions[] = {
+static zend_function_entry facedetect_functions[] = {
     PHP_FE(face_detect, NULL)
     PHP_FE(face_count, NULL)
     {NULL, NULL, NULL}


### PR DESCRIPTION
function_entry is drop in PHP 5.4
zend_function_entry should be used instead, which is available since php 5.0.0
