### PR TITLE
Fix configure script syntax

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -39,7 +39,7 @@ if test "$PHP_FACEDETECT" != "no"; then
     ],[
       AC_MSG_ERROR([Wrong OpenCV version or OpenCV not found]) 
       ],[
-    ]),
+    ])
   ],[
     AC_MSG_ERROR([wrong OpenCV version or OpenCV not found])
   ],[


### PR DESCRIPTION
./configure: line 4677: ,: command not found