### PR TITLE
retrieve opencv build options from pkg_config

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -1,49 +1,22 @@
 PHP_ARG_WITH(facedetect, for facedetect support, [  --with-facedetect     Enable facedetect support])
 
 if test "$PHP_FACEDETECT" != "no"; then
-  SEARCH_PATH="/usr/local /usr /opt/local"
-  SEARCH_FOR="/include/opencv2/core/core_c.h"
-
-  if test -r $PHP_FACEDETECT/$SEARCH_FOR; then
-    FACEDETECT_DIR=$PHP_FACEDETECT
+  AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
+  AC_MSG_CHECKING(for opencv)
+  if test -x "$PKG_CONFIG" && $PKG_CONFIG --exists opencv; then
+    CV_INCLUDE=`$PKG_CONFIG opencv --variable=includedir_new`
+    CV_LIBRARY=`$PKG_CONFIG opencv --libs`
+    CV_VERSION=`$PKG_CONFIG opencv --modversion`
+    if $PKG_CONFIG opencv --atleast-version=2.2.0 ; then
+      AC_MSG_RESULT($CV_VERSION)
+    else
+      AC_MSG_ERROR(opencv version is too old)
+    fi
+    PHP_EVAL_LIBLINE($CV_LIBRARY, FACEDETECT_SHARED_LIBADD)
+    PHP_ADD_INCLUDE($CV_INCLUDE)
   else
-    AC_MSG_CHECKING([for facedetect in default path])
-    for i in $SEARCH_PATH ; do
-      if test -r $i/$SEARCH_FOR; then
-        FACEDETECT_DIR=$i
-        AC_MSG_RESULT(found in $i)
-	break
-      fi
-    done
+    AC_MSG_ERROR(Please reinstall opencv)
   fi
-
-  if test -z "$FACEDETECT_DIR"; then
-    AC_MSG_RESULT([not found])
-    AC_MSG_ERROR([Please reinstall the OpenCV distribution])
-  fi
-
-  PHP_ADD_INCLUDE($FACEDETECT_DIR/include)
-
-  AC_CHECK_HEADER([$FACEDETECT_DIR/include/opencv2/core/core_c.h], [], AC_MSG_ERROR('opencv/core/core_c.h' header not found))
-  AC_CHECK_HEADER([$FACEDETECT_DIR/include/opencv2/imgproc/imgproc_c.h], [], AC_MSG_ERROR('opencv/imgproc/imgproc_c.h' header not found))
-  AC_CHECK_HEADER([$FACEDETECT_DIR/include/opencv2/photo/photo_c.h], [], AC_MSG_ERROR('opencv/photo/photo_c.h' header not found))
-  AC_CHECK_HEADER([$FACEDETECT_DIR/include/opencv2/objdetect/objdetect_c.h], [], AC_MSG_ERROR('opencv/objdetect/objdetect_c.h' header not found))
-
-  PHP_CHECK_LIBRARY(opencv_core, cvLoad,
-  [
-    PHP_ADD_LIBRARY_WITH_PATH(opencv_core, $FACEDETECT_DIR/lib, FACEDETECT_SHARED_LIBADD)
-    PHP_CHECK_LIBRARY(opencv_objdetect, cvHaarDetectObjects,
-    [
-      PHP_ADD_LIBRARY_WITH_PATH(opencv_objdetect, $FACEDETECT_DIR/lib, FACEDETECT_SHARED_LIBADD)
-      AC_DEFINE(HAVE_FACEDETECT, 1, [ ])
-    ],[
-      AC_MSG_ERROR([Wrong OpenCV version or OpenCV not found]) 
-      ],[
-    ])
-  ],[
-    AC_MSG_ERROR([wrong OpenCV version or OpenCV not found])
-  ],[
-  ])
 
   PHP_SUBST(FACEDETECT_SHARED_LIBADD)
   AC_DEFINE(HAVE_FACEDETECT, 1, [ ])


### PR DESCRIPTION
Trying to build with OpenCV 3.1 result in:

`PHP Warning:  PHP Startup: Unable to load dynamic library '/builddir/build/BUILDROOT/php-facedetect-1.1.0-3.fc26.i386/usr/lib/php/modules/facedetect.so' - /builddir/build/BUILDROOT/php-facedetect-1.1.0-3.fc26.i386/usr/lib/php/modules/facedetect.so: undefined symbol: cvLoadImage in Unknown on line 0`

Obviously, more libraries are needed, so the config.m4 need to be fixed.

Notice: current version uses `$FACEDETECT_DIR/lib` which is wrong, `$FACEDETECT_DIR/$PHP_LIBDIR` being the correct way (could be /lib or /lib64)

This patch is a big cleanup, using "only" pkg-config  output to rerieve build options.
