### PR TITLE
drop ZVAL_NEW_ARR usage for PHP 8.1

### DIFF
--- a/facedetect.cc
+++ b/facedetect.cc
@@ -101,7 +101,7 @@ static void php_facedetect(INTERNAL_FUNCTION_PARAMETERS, int return_type) {
 
         for (size_t i = 0; i < faces.size(); i++) {
 #if PHP_VERSION_ID >= 70000
-            ZVAL_NEW_ARR(&array);
+            array_init(&array);
             pArray = &array;
 #else
             MAKE_STD_ZVAL(array);


### PR DESCRIPTION
From UPGRADING.INTERNALS

`     - The ZVAL_NEW_ARR() macro has been removed. Use array_init() or ZVAL_ARR`

Array_init is enough with PHP  7+